### PR TITLE
Enable CORS in Flask backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from flask import Flask, request, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import create_access_token, jwt_required, JWTManager, get_jwt_identity
+from flask_cors import CORS
 from alpha_vantage.foreignexchange import ForeignExchange
 from alpha_vantage.timeseries import TimeSeries
 import requests # for potential error handling
@@ -19,6 +20,7 @@ app.config['ALPHA_VANTAGE_API_KEY'] = os.environ.get('ALPHA_VANTAGE_API_KEY', 'Y
 # Initialize Extensions
 from models import db, User, EducationalContent, Asset, Trade, PortfolioHolding
 db.init_app(app)
+CORS(app, resources={r'/*': {'origins': ['http://localhost:3000', 'http://127.0.0.1:3000']}}, supports_credentials=True)
 jwt = JWTManager(app)
 
 # --- Database Initialization Command (for development) ---

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ Flask-JWT-Extended
 Werkzeug
 alpha_vantage
 requests
+Flask-CORS


### PR DESCRIPTION
Adds Flask-CORS to the backend application to allow cross-origin requests from the frontend development server (typically http://localhost:3000).

- Added 'Flask-CORS' to backend/requirements.txt.
- Initialized CORS in backend/app.py, configuring it to accept requests from 'http://localhost:3000' and 'http://127.0.0.1:3000' for all routes and to support credentials.

This change is intended to resolve issues where browser security policies (CORS) were preventing the frontend from successfully making POST/PUT/DELETE requests to the backend, such as during user registration.