### PR TITLE
feat: Implement token expiration handling and setup for testing

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('postgresql://trader_app_user:a_much_stronger_password@localhost:5432/trader_db', 'postgresql://trader_app_user:a_much_stronger_password@localhost/trader_db')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['JWT_SECRET_KEY'] = os.environ.get('JWT_SECRET_KEY', 'super-secret-dev-key')
+app.config['JWT_ACCESS_TOKEN_EXPIRES'] = 10 # Expires in 10 seconds for testing
 app.config['ALPHA_VANTAGE_API_KEY'] = os.environ.get('ALPHA_VANTAGE_API_KEY', 'YOUR_ALPHA_VANTAGE_API_KEY')
 
 # Initialize CORS - Placed after config and before other extensions

--- a/frontend-web/src/services/api.js
+++ b/frontend-web/src/services/api.js
@@ -1,0 +1,32 @@
+// frontend-web/src/services/api.js
+import axios from 'axios';
+import authService from './authService'; // Assuming authService is in the same directory
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const originalRequest = error.config;
+    // Check if the error is a 401, not from a login attempt, and not already a retry
+    if (error.response && error.response.status === 401 && originalRequest.url !== `${API_URL}/auth/login` && originalRequest.url !== `${API_URL}/auth/register`) {
+      console.warn('Axios interceptor: Detected 401 error. Logging out.');
+      authService.logout(); // Clear token and user state
+
+      // Redirect to login page
+      // Avoid redirect loop if already on login or if public pages are involved
+      if (window.location.pathname !== '/login' && window.location.pathname !== '/register') {
+        window.location.href = '/login';
+        // For React Router, you might use a navigation service or history object
+        // e.g., history.push('/login');
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;

--- a/frontend-web/src/services/assetService.js
+++ b/frontend-web/src/services/assetService.js
@@ -1,7 +1,8 @@
-import axios from 'axios';
-import authService from './authService'; // For getting the auth token
+import apiClient from './api'; // Changed from axios
+import authService from './authService';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+// API_URL is now managed by apiClient
+// const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 
 const getAuthHeaders = () => {
   const token = authService.getAuthToken();

--- a/frontend-web/src/services/portfolioService.js
+++ b/frontend-web/src/services/portfolioService.js
@@ -1,8 +1,9 @@
 // frontend-web/src/services/portfolioService.js
-import axios from 'axios';
+import apiClient from './api'; // Changed from axios
 import authService from './authService';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+// API_URL is now managed by apiClient
+// const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 
 const getAuthHeaders = () => {
   const token = authService.getAuthToken();
@@ -13,7 +14,8 @@ const getAuthHeaders = () => {
 };
 
 const getPortfolio = () => {
-  return axios.get(`${API_URL}/portfolio`, { headers: getAuthHeaders() });
+  // Changed from axios.get(`${API_URL}/portfolio`...) to apiClient.get('/portfolio'...)
+  return apiClient.get(`/portfolio`, { headers: getAuthHeaders() });
 };
 
 const portfolioService = {


### PR DESCRIPTION
Frontend:
- I created `frontend-web/src/services/api.js` with a configured Axios client (`apiClient`).
- This `apiClient` includes a response interceptor to globally handle 401 errors. Upon detecting a 401 (excluding on login/register attempts), it logs you out via `authService.logout()` and redirects to the `/login` page.
- I updated `assetService.js` and `portfolioService.js` to use this new `apiClient` for their requests.

Backend:
- I temporarily modified `backend/app.py` to set `app.config['JWT_ACCESS_TOKEN_EXPIRES'] = 10`. This is for testing the frontend's ability to handle token expiration. This change should be reverted after testing.

These changes prepare the application for testing the token expiration flow.